### PR TITLE
fix!: failed deployment plugin didnt trigger git tag deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,55 +2,76 @@
 
 [semantic-release](https://github.com/semantic-release/semantic-release) plugin to recover from a failed deployment. 
 
-Deployment failures can happen for a variety of reasons. It's best to plan for when they happen instead of trying to prevent them from happening in the first place. When you run `semantic-release` to perform a deployment and a failure happens (perhaps the npmjs server is down), unfortunately, you cannot simply click the retry button on your CI server to retry the deployment later. `semantic-release` performs some modifications to your project such as pushing a new git tag to your repository which will then skip a deployment if you perform a retry. 
+Deployment failures can happen for a variety of reasons. When you run `semantic-release` to perform a deployment and a failure happens (perhaps the npmjs server is down), unfortunately, you cannot simply click the retry button on your CI server to retry the deployment later. `semantic-release` performs some modifications to your project such as pushing a new git tag to your repository which will then skip a deployment if you perform a retry. 
 
-I believe that retrying should be as easy as, well, retrying. Especially when working on a team, I prefer that they do not need to figure out this behavior of `semantic-release` on their own and instead the deployment process can recover for them. 
+I believe that retrying should be as easy as, well, retrying. Especially when working on a team, I prefer that they do not need to figure out this behavior of `semantic-release` on their own and instead the deployment process can recover for them. That's why this plugin was created. To recover from a failed deployment and allow anyone to retry the deployment without any manual work. 
 
 # Getting Started
 
 * Install the plugin: `npm install semantic-release-recovery`
 
-* Add to your project workflow: 
+* Add to your project workflow. The syntax of this plugin is: 
+
+```json
+["semantic-release-recovery", { "plugins": [
+    <your-semantic-release-deployment-plugin-here>
+]}]
+```
+
+Let's use an example. Imagine that you have a semantic-release config file that includes the `@semantic-release/npm` plugin that performs the deployment for us: 
 
 ```json
 {
-    "tagFormat": "${version}",
-    "branches": [
-        "main",
-        { "name": "beta", "prerelease": true },
-        { "name": "alpha", "prerelease": true }
-    ],
     "plugins": [
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",        
-        ["semantic-release-recovery", [
-            ["@semantic-release/npm", {
-                "distTag": "next"
-            }]
-        ]]
+        ["@semantic-release/npm", {
+            "distTag": "next"
+        }]        
     ]
 }
 ```
 
-* For simple projects, this might be all that you need to do. I suggest reading the section on [creating a recovery plan](#what-recovery-steps-should-my-project-take) to learn more about how to prepare for a failed deployment. 
+Wrap the existing `@semantic-release/npm` configuration by `semantic-release-recovery`: 
 
-# What recovery steps should my project take? 
+```json
+{
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",        
+        ["semantic-release-recovery", { "plugins": [
+            ["@semantic-release/npm", {
+                "distTag": "next"
+            }]   
+        ]}]  
+    ]
+}
+```
 
-Every project is different for what the deployment process looks like. You will need to decide what needs to be done in order to create a fully automated deployment failure recovery process. Here are some suggestions to help you to create your recovery plan. 
+If your project uses multiple plugins for deployment, you can use an array: 
 
-* If `semantic-release` attempted to deploy `2.3.1` of your software and failed, you must delete the git tag `2.3.1` that got pushed to your git repository if you want `semantic-release` to retry pushing `2.3.1` again. That is the main function of this plugin is to delete the git tag if a failure occurs. Although, [you can disable this behavior](#configuration) if needed for some reason. 
-
-* If `semantic-release` successfully pushed version `2.3.1` successfully to a production server such as npmjs.com, you should *not* retry pushing version `2.3.1` to the server again. Most services that you upload to require deployments to be immutable. This plugin cannot help you with this step, however. 
-
-* If `semantic-release` created a git commit for modifications to a `CHANGELOG.md` file, for example, you can revert that git commit, or you can decide not to do anything. Because the git tag that points to the git commit gets deleted, the commit has less of a meaning to it. 
-
-In general, it's up to you to decide what a successful deployment looks like. However, keep in mind that a core requirement of `semantic-release` is that a git tag must be pushed to your git repository in order to determine a deployment was successful. 
+```json
+{
+    "plugins": [
+        "@semantic-release/commit-analyzer",
+        "@semantic-release/release-notes-generator",        
+        ["semantic-release-recovery", { "plugins": [
+            ["@semantic-release/npm", {
+                "distTag": "next"
+            }],
+            ["@semantic-release/exec", {
+                "publishCmd": "docker push..."
+            }]   
+        ]}]  
+    ]
+}
+```
 
 # Vision for this project
 
 This project's vision is led by fundamental goals that this plugin is trying to accomplish. With all future development, we try to follow these goals. 
 
-1. When using `semantic-release` with a team, everyone on your team should be able to help retry a deployment. Someone who has never used `semantic-release` before should be able to see a failed deployment and retry it. 
+1. When using `semantic-release` with a team, anyone on your team should be able to retry a deployment. Someone who has never used `semantic-release` before should be able to see a failed deployment and retry it. 
 2. Deployment failures should not be scary to recover from. It can be scary to run git commands to recover from a deployment failure. Typos can happen! This plugin should help to prevent the need to run commands manually to avoid anyone on your team needing to feel scared. Let's make deployment failures calm 😄. 
 
 # Why is this plugin needed? 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ I believe that retrying should be as easy as, well, retrying. Especially when wo
     "plugins": [
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",        
-        "@semantic-release/npm", 
-        "semantic-release-recovery"
+        ["semantic-release-recovery", [
+            ["@semantic-release/npm", {
+                "distTag": "next"
+            }]
+        ]]
     ]
 }
 ```

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -11,6 +11,10 @@ module.exports = {
   collectCoverage: true,
   clearMocks: true,  
   restoreMocks: true, // resets spys 
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   // [...]
   transform: {
     ...tsjPreset.transform,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,9 @@
         "semantic-release": "^21.1.1",
         "ts-jest": "^29.1.1",
         "typescript": "^5.2.2"
+      },
+      "peerDependencies": {
+        "semantic-release": ">=18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "homepage": "https://github.com/levibostian/semantic-release-recovery#readme",
   "author": "Levi Bostian <levi@curiosityio.com>",
   "license": "MIT",
+  "type": "module",
   "devDependencies": {
     "@tsconfig/node18": "^18.2.1",
     "@types/jest": "^29.5.4",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "[semantic-release](https://github.com/semantic-release/semantic-release) plugin to recover from a failed deployment.",
   "main": "dist/index.js",
   "scripts": {
-    "test": "npx jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest",
     "compile": "npx tsc --outDir dist"
   },
   "homepage": "https://github.com/levibostian/semantic-release-recovery#readme",

--- a/src/exec.ts
+++ b/src/exec.ts
@@ -1,17 +1,42 @@
 import { execSync } from 'child_process';
 import { BaseContext } from "semantic-release"
 
-export async function runCommand(command: string, context: BaseContext): Promise<void> {
-  try {
-    let stdout = execSync(command)
-    context.logger.log(stdout.toString())
-  } catch (error: any) {
-    let stdout = error.stdout.toString()
-    if (stdout) context.logger.log(stdout) 
+export interface Exec {
+  runCommand(command: string, context: BaseContext): Promise<void> 
+}
 
-    let stderr = error.stderr.toString()
-    if (stderr) context.logger.error(stderr) 
-    
-    throw error
+class ExecImpl implements Exec {
+  async runCommand(command: string, context: BaseContext): Promise<void> {
+    try {
+      let stdout = execSync(command)
+      context.logger.log(stdout.toString())
+    } catch (error: any) {
+      let stdout = error.stdout.toString()
+      if (stdout) context.logger.log(stdout) 
+  
+      let stderr = error.stderr.toString()
+      if (stderr) context.logger.error(stderr) 
+      
+      throw error
+    }
   }
 }
+
+export class ExecMock implements Exec {  
+  callCount: Map<string, number> = new Map()
+  call: Map<string, any> = new Map()
+  calls: Map<string, any[]> = new Map()
+
+  runCommand(command: string, context: BaseContext ): Promise<void> {
+    this.callCount.set('runCommand', (this.callCount.get('runCommand') || 0) + 1)
+    this.call.set('runCommand', {command, context})
+
+    let existingCalls = this.calls.get('runCommand') || []
+    existingCalls.push({command, context})
+    this.calls.set('runCommand', existingCalls)
+
+    return Promise.resolve()
+  }
+}
+
+export const exec: Exec = new ExecImpl()

--- a/src/git.spec.ts
+++ b/src/git.spec.ts
@@ -1,6 +1,6 @@
-import * as exec from "./exec.js"
+import { ExecMock } from "./exec.js"
 import { BaseContext } from 'semantic-release';
-import * as git from "./git.js"
+import { GitImpl } from "./git.js"
 
 let context: BaseContext & {options: {dryRun: boolean}} = {  
   logger: {
@@ -15,14 +15,20 @@ let context: BaseContext & {options: {dryRun: boolean}} = {
   }
 }
 
+let execMock = new ExecMock()
+let git = new GitImpl(execMock)
+beforeAll(() => {
+  execMock = new ExecMock()
+  git = new GitImpl(execMock)
+})
+
 describe('deleteTag', () => {
   it('expect git command string', async () => {
     const exectedCommand = 'git push origin --delete v1.0.0' 
 
-    jest.spyOn(exec, 'runCommand').mockReturnValue(Promise.resolve())
-
     await git.deleteTag("v1.0.0", context)
-
-    expect(exec.runCommand).toHaveBeenCalledWith(exectedCommand, context)
+    
+    expect(execMock.callCount.get('runCommand')).toBe(1)
+    expect(execMock.call.get('runCommand').command).toBe(exectedCommand)
   });
 })

--- a/src/git.spec.ts
+++ b/src/git.spec.ts
@@ -16,28 +16,12 @@ let context: BaseContext & {options: {dryRun: boolean}} = {
 }
 
 describe('deleteTag', () => {
-  it('given not running in dry-mode, expect git command string', async () => {
-    const exectedCommand = 'git push origin --delete v1.0.0'
-    const givenIsInDryMode = false 
-
-    context.options.dryRun = givenIsInDryMode
+  it('expect git command string', async () => {
+    const exectedCommand = 'git push origin --delete v1.0.0' 
 
     jest.spyOn(exec, 'runCommand').mockReturnValue(Promise.resolve())
 
-    await git.deleteTag("v1.0.0", givenIsInDryMode, context)
-
-    expect(exec.runCommand).toHaveBeenCalledWith(exectedCommand, context)
-  });
-
-  it('given running in dry-mode, expect git command string', async () => {
-    const exectedCommand = 'git push origin --delete v1.0.0 --dry-run'
-    const givenIsInDryMode = true
-
-    context.options.dryRun = givenIsInDryMode 
-
-    jest.spyOn(exec, 'runCommand').mockReturnValue(Promise.resolve())
-
-    await git.deleteTag("v1.0.0", givenIsInDryMode, context)
+    await git.deleteTag("v1.0.0", context)
 
     expect(exec.runCommand).toHaveBeenCalledWith(exectedCommand, context)
   });

--- a/src/git.spec.ts
+++ b/src/git.spec.ts
@@ -1,6 +1,6 @@
-import * as exec from "./exec"
+import * as exec from "./exec.js"
 import { BaseContext } from 'semantic-release';
-import * as git from "./git"
+import * as git from "./git.js"
 
 let context: BaseContext & {options: {dryRun: boolean}} = {  
   logger: {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,4 @@
-import { runCommand } from "./exec"
+import { runCommand } from "./exec.js"
 import { BaseContext } from "semantic-release"
 
 export async function deleteTag(tagName: string, context: BaseContext): Promise<void> {

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,9 +1,8 @@
 import { runCommand } from "./exec"
 import { BaseContext } from "semantic-release"
 
-export async function deleteTag(tagName: string, dryRun: Boolean, context: BaseContext): Promise<void> {
+export async function deleteTag(tagName: string, context: BaseContext): Promise<void> {
   let command = `git push origin --delete ${tagName}`
-  if (dryRun) command += ` --dry-run`
 
   context.logger.log(`Running git command: \`${command}\``)
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,10 +1,47 @@
-import { runCommand } from "./exec.js"
+import { Exec, exec } from "./exec.js"
 import { BaseContext } from "semantic-release"
 
-export async function deleteTag(tagName: string, context: BaseContext): Promise<void> {
-  let command = `git push origin --delete ${tagName}`
+export interface Git {
+  deleteTag(tagName: string, context: BaseContext): Promise<void>
+}
 
-  context.logger.log(`Running git command: \`${command}\``)
+export class GitImpl implements Git {
+  private _exec: Exec 
 
-  await runCommand(command, context)  
+  constructor(execImpl: Exec = exec) {
+    this._exec = execImpl
+  }
+
+  async deleteTag(tagName: string, context: BaseContext): Promise<void> {
+    let command = `git push origin --delete ${tagName}`
+
+    context.logger.log(`Running git command: \`${command}\``)
+
+    await this._exec.runCommand(command, context) 
+  }
+}
+
+class GitMock implements Git {  
+  callCount: Map<string, number> = new Map()
+  call: Map<string, any> = new Map()
+  calls: Map<string, any[]> = new Map()
+
+  async deleteTag(tagName: string, context: BaseContext): Promise<void> {
+    this.callCount.set('deleteTag', (this.callCount.get('deleteTag') || 0) + 1)
+    this.call.set('deleteTag', {tagName, context})
+
+    let existingCalls = this.calls.get('deleteTag') || []
+    existingCalls.push({tagName, context})
+    this.calls.set('deleteTag', existingCalls)
+
+    return Promise.resolve()
+  }
+}
+
+export let git: Git = new GitImpl()
+export let gitMock = new GitMock()
+
+export const mockGit = () => {
+  gitMock = new GitMock()
+  git = gitMock
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,143 +1,143 @@
-import { FailContext, VerifyConditionsContext, VerifyReleaseContext } from 'semantic-release';
-import { verifyConditions, verifyRelease, fail } from './index';
-import * as git from './git';
-import * as exec from "./exec"
+// import { FailContext, VerifyConditionsContext, VerifyReleaseContext } from 'semantic-release';
+// import { verifyConditions, verifyRelease, fail } from './index';
+// import * as git from './git';
+// import * as exec from "./exec"
 
-let context: VerifyConditionsContext & VerifyReleaseContext & FailContext & {options: {dryRun: boolean}} = {
-  env: {},
-  envCi: {
-    isCi: true,
-    commit: '1234567890',
-    branch: 'main',
-  },
-  logger: {
-    log: (message: string) => {
-      console.log(message)
-    }
-  },
-  branch: {
-    name: 'main'
-  },
-  branches: [{name: 'main'}],
-  stderr: process.stderr,
-  stdout: process.stdout,
-  nextRelease: {
-    channel: 'main',
-    name: 'main',
-    type: 'major',
-    version: '1.0.0',
-    gitTag: 'v1.0.0',
-    gitHead: '1234567890',
-    notes: 'Release notes'
-  },
-  commits: [],
-  releases: [],
-  lastRelease: {
-    version: '',
-    gitTag: '',
-    channels: [],
-    gitHead: '',
-    name: '',
-  },
-  errors: {
-    errors: [],
-    message: '',
-    name: ''
-  },
-  options: {
-    dryRun: true
-  }
-}
+// let context: VerifyConditionsContext & VerifyReleaseContext & FailContext & {options: {dryRun: boolean}} = {
+//   env: {},
+//   envCi: {
+//     isCi: true,
+//     commit: '1234567890',
+//     branch: 'main',
+//   },
+//   logger: {
+//     log: (message: string) => {
+//       console.log(message)
+//     }
+//   },
+//   branch: {
+//     name: 'main'
+//   },
+//   branches: [{name: 'main'}],
+//   stderr: process.stderr,
+//   stdout: process.stdout,
+//   nextRelease: {
+//     channel: 'main',
+//     name: 'main',
+//     type: 'major',
+//     version: '1.0.0',
+//     gitTag: 'v1.0.0',
+//     gitHead: '1234567890',
+//     notes: 'Release notes'
+//   },
+//   commits: [],
+//   releases: [],
+//   lastRelease: {
+//     version: '',
+//     gitTag: '',
+//     channels: [],
+//     gitHead: '',
+//     name: '',
+//   },
+//   errors: {
+//     errors: [],
+//     message: '',
+//     name: ''
+//   },
+//   options: {
+//     dryRun: true
+//   }
+// }
 
-describe(('Test fail function, deleting git tag'), () => {
-  it('given running in dry-mode, expect to run git command also in dry-mode', async () => {
-    context.options.dryRun = true 
+// describe(('Test fail function, deleting git tag'), () => {
+//   it('given running in dry-mode, expect to run git command also in dry-mode', async () => {
+//     context.options.dryRun = true 
 
-    jest.spyOn(git, 'deleteTag').mockReturnValue(Promise.resolve())
+//     jest.spyOn(git, 'deleteTag').mockReturnValue(Promise.resolve())
 
-    await verifyConditions({}, context)
-    await verifyRelease({}, context)
-    await fail({}, context)
+//     await verifyConditions({}, context)
+//     await verifyRelease({}, context)
+//     await fail({}, context)
 
-    expect(git.deleteTag).toHaveBeenCalledWith('v1.0.0', true, context)
-  });
+//     expect(git.deleteTag).toHaveBeenCalledWith('v1.0.0', true, context)
+//   });
 
-  it('given not running in dry-mode, expect to run git command not in dry-mode', async () => {
-    context.options.dryRun = false
+//   it('given not running in dry-mode, expect to run git command not in dry-mode', async () => {
+//     context.options.dryRun = false
 
-    jest.spyOn(git, 'deleteTag').mockReturnValue(Promise.resolve())
+//     jest.spyOn(git, 'deleteTag').mockReturnValue(Promise.resolve())
 
-    await verifyConditions({}, context)
-    await verifyRelease({}, context)
-    await fail({}, context)
+//     await verifyConditions({}, context)
+//     await verifyRelease({}, context)
+//     await fail({}, context)
 
-    expect(git.deleteTag).toHaveBeenCalledWith('v1.0.0', false, context)
-  });
+//     expect(git.deleteTag).toHaveBeenCalledWith('v1.0.0', false, context)
+//   });
 
-  it('given no next release made, expect skip running plugin', async () => {
-    jest.spyOn(git, 'deleteTag').mockReturnValue(Promise.resolve())
+//   it('given no next release made, expect skip running plugin', async () => {
+//     jest.spyOn(git, 'deleteTag').mockReturnValue(Promise.resolve())
 
-    await verifyConditions({}, context)
-    // skip running verify release as semantic-release would not call this function if no next release 
-    await fail({}, context)
+//     await verifyConditions({}, context)
+//     // skip running verify release as semantic-release would not call this function if no next release 
+//     await fail({}, context)
 
-    expect(git.deleteTag).not.toHaveBeenCalled()
-  });
-});
+//     expect(git.deleteTag).not.toHaveBeenCalled()
+//   });
+// });
 
-describe('logging', () => {
-  let contextWithLogger = context
-  let logMock = jest.fn()
-  contextWithLogger.logger.log = logMock
+// describe('logging', () => {
+//   let contextWithLogger = context
+//   let logMock = jest.fn()
+//   contextWithLogger.logger.log = logMock
 
-  beforeEach(async() => {
-    jest.spyOn(exec, 'runCommand').mockResolvedValue(Promise.resolve())
-  })
+//   beforeEach(async() => {
+//     jest.spyOn(exec, 'runCommand').mockResolvedValue(Promise.resolve())
+//   })
 
-  it('should generate logs that is expected, given running in dry-mode', async () => {
-    contextWithLogger.options.dryRun = true 
+//   it('should generate logs that is expected, given running in dry-mode', async () => {
+//     contextWithLogger.options.dryRun = true 
 
-    await verifyConditions({}, contextWithLogger)
-    await verifyRelease({}, contextWithLogger)
-    await fail({}, contextWithLogger)
+//     await verifyConditions({}, contextWithLogger)
+//     await verifyRelease({}, contextWithLogger)
+//     await fail({}, contextWithLogger)
 
-    const actualLogs = logMock.mock.calls.flatMap((call) => call[0])
+//     const actualLogs = logMock.mock.calls.flatMap((call) => call[0])
 
-    expect(actualLogs).toMatchInlineSnapshot(`
-[
-  "👋 Hello from the semantic-release-recovery plugin! My job is to gracefully handle failed deployments so you can simply re-try the deployment if you wish. Without a plugin like this, you would have to manually clean up the failed deployment in order to retry. You can learn more about failed deployment cleanup recommendations here: https://github.com/levibostian/semantic-release-recovery#readme",
-  "Oh, it looks like you are running your deployment with dry-mode enabled. I will make sure all commands I run are also run in dry-mode. I got you! 👊",
-  "Next release is planned to be: v1.0.0. If this deployment fails, I will delete the git tag: v1.0.0.",
-  "Well, I will pretend to delete it, since you are running in dry-mode. 😉",
-  "Looks like something went wrong during the deployment. No worries! I will try to help by cleaning up after the failed deployment so you can re-try the deployment if you wish.",
-  "Deleting git tag v1.0.0...",
-  "(Well, not really deleting it. You are running in dry-mode. I am just playing pretend here. 🧙‍♂️)",
-  "Running git command: \`git push origin --delete v1.0.0 --dry-run\`",
-  "Done! Cleanup is complete and you should be able to retry the deployment now.",
-  "Well, technically a deployment was not actually attempted. You can try for *real* now. 😉",
-]
-`)
-  })
+//     expect(actualLogs).toMatchInlineSnapshot(`
+// [
+//   "👋 Hello from the semantic-release-recovery plugin! My job is to gracefully handle failed deployments so you can simply re-try the deployment if you wish. Without a plugin like this, you would have to manually clean up the failed deployment in order to retry. You can learn more about failed deployment cleanup recommendations here: https://github.com/levibostian/semantic-release-recovery#readme",
+//   "Oh, it looks like you are running your deployment with dry-mode enabled. I will make sure all commands I run are also run in dry-mode. I got you! 👊",
+//   "Next release is planned to be: v1.0.0. If this deployment fails, I will delete the git tag: v1.0.0.",
+//   "Well, I will pretend to delete it, since you are running in dry-mode. 😉",
+//   "Looks like something went wrong during the deployment. No worries! I will try to help by cleaning up after the failed deployment so you can re-try the deployment if you wish.",
+//   "Deleting git tag v1.0.0...",
+//   "(Well, not really deleting it. You are running in dry-mode. I am just playing pretend here. 🧙‍♂️)",
+//   "Running git command: \`git push origin --delete v1.0.0 --dry-run\`",
+//   "Done! Cleanup is complete and you should be able to retry the deployment now.",
+//   "Well, technically a deployment was not actually attempted. You can try for *real* now. 😉",
+// ]
+// `)
+//   })
 
-  it('should generate logs that is expected', async () => {
-    contextWithLogger.options.dryRun = false
+//   it('should generate logs that is expected', async () => {
+//     contextWithLogger.options.dryRun = false
 
-    await verifyConditions({}, contextWithLogger)
-    await verifyRelease({}, contextWithLogger)
-    await fail({}, contextWithLogger)
+//     await verifyConditions({}, contextWithLogger)
+//     await verifyRelease({}, contextWithLogger)
+//     await fail({}, contextWithLogger)
 
-    const actualLogs = logMock.mock.calls.flatMap((call) => call[0])
+//     const actualLogs = logMock.mock.calls.flatMap((call) => call[0])
 
-    expect(actualLogs).toMatchInlineSnapshot(`
-[
-  "👋 Hello from the semantic-release-recovery plugin! My job is to gracefully handle failed deployments so you can simply re-try the deployment if you wish. Without a plugin like this, you would have to manually clean up the failed deployment in order to retry. You can learn more about failed deployment cleanup recommendations here: https://github.com/levibostian/semantic-release-recovery#readme",
-  "Next release is planned to be: v1.0.0. If this deployment fails, I will delete the git tag: v1.0.0.",
-  "Looks like something went wrong during the deployment. No worries! I will try to help by cleaning up after the failed deployment so you can re-try the deployment if you wish.",
-  "Deleting git tag v1.0.0...",
-  "Running git command: \`git push origin --delete v1.0.0\`",
-  "Done! Cleanup is complete and you should be able to retry the deployment now.",
-]
-`)
-  })
-})
+//     expect(actualLogs).toMatchInlineSnapshot(`
+// [
+//   "👋 Hello from the semantic-release-recovery plugin! My job is to gracefully handle failed deployments so you can simply re-try the deployment if you wish. Without a plugin like this, you would have to manually clean up the failed deployment in order to retry. You can learn more about failed deployment cleanup recommendations here: https://github.com/levibostian/semantic-release-recovery#readme",
+//   "Next release is planned to be: v1.0.0. If this deployment fails, I will delete the git tag: v1.0.0.",
+//   "Looks like something went wrong during the deployment. No worries! I will try to help by cleaning up after the failed deployment so you can re-try the deployment if you wish.",
+//   "Deleting git tag v1.0.0...",
+//   "Running git command: \`git push origin --delete v1.0.0\`",
+//   "Done! Cleanup is complete and you should be able to retry the deployment now.",
+// ]
+// `)
+//   })
+// })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
 import { FailContext, VerifyReleaseContext, VerifyConditionsContext, AnalyzeCommitsContext, PrepareContext, PublishContext, AddChannelContext, SuccessContext, BaseContext } from "semantic-release"
 import { PluginConfig, parseConfig, DeploymentPlugin } from "./type/pluginConfig.js";
-import * as npm from "./npm.js";
+import {npm} from "./npm.js";
 import { SemanticReleasePlugin } from "./type/semanticReleasePlugin.js";
-import * as git from "./git.js"
+import {git} from "./git.js"
 import { getDeploymentPluginLogger, getLogger } from "./logger.js"
 
 // global variables used by the whole plugin as it goes through semantic-release lifecycle
@@ -96,6 +96,8 @@ export async function prepare(pluginConfig: PluginConfig, context: PrepareContex
 }
 
 export async function publish(pluginConfig: PluginConfig, context: PublishContext) {
+  context.logger.log(`Next release is planned to be: ${context.nextRelease.version}. If this deployment fails, I will delete the git tag: ${context.nextRelease.gitTag}`)
+
   for (const deployPlugin of deploymentPlugins) {
     if (deployPlugin.module.publish) {
       modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: false})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,47 +1,157 @@
-import { FailContext, NextRelease, VerifyReleaseContext, VerifyConditionsContext } from "semantic-release"
+import { FailContext, VerifyReleaseContext, VerifyConditionsContext, AnalyzeCommitsContext, PrepareContext, PublishContext, AddChannelContext, SuccessContext, BaseContext } from "semantic-release"
+import { PluginConfig, parseConfig, DeploymentPlugin } from "./type/pluginConfig";
+import * as npm from "./npm";
+import { SemanticReleasePlugin } from "./type/semanticReleasePlugin";
 import * as git from "./git"
 
-let nextRelease: NextRelease | undefined;
-let isDryRun: boolean = false;
+// global variables used by the whole plugin as it goes through semantic-release lifecycle
+// Deployment plugins that are parsed, loaded, and ready to call functions on. 
+let deploymentPlugins: Array<{module: SemanticReleasePlugin, config: DeploymentPlugin}> = []
 
-const packageInfo: { name: string, homepage: string } = require("../package.json")
+export function resetPlugin() { // useful for running tests 
+  deploymentPlugins = []
+}
 
-export async function verifyConditions(pluginConfig: {}, context: VerifyConditionsContext & {options: {dryRun: boolean}}) {
-  nextRelease = undefined // to reset the plugin's state 
+// semantic-release uses a lib called signale for logging. This lib helps semantic-release make logs better by telling you what plugin is executing. 
+// Because this plugin's job is to execute another plugin, we want to do the same thing that semantic-release does to show when the deploy plugin is executing. 
+// We should see logs such as: 
+// [semantic-release] [semantic-release-precheck] Running verifyConditions for deployment plugin: @semantic-release/npm
+// [semantic-release] [@semantic-release/npm] running publish step here. 
+// Depending on what plugin is running, our precheck plugin or the deploy plugin. 
+// 
+// This function modifies the context object with the modified logger so we can send the modified context to the deploy plugin.
+export function prepareLoggerForDeploymentPlugin<CONTEXT>(context: BaseContext, deploymentPlugin: DeploymentPlugin): CONTEXT {
+  let logger = context.logger 
 
-  context.logger.log(`👋 Hello from the ${packageInfo.name} plugin! My job is to gracefully handle failed deployments so you can simply re-try the deployment if you wish. Without a plugin like this, you would have to manually clean up the failed deployment in order to retry. You can learn more about failed deployment cleanup recommendations here: ${packageInfo.homepage}`)
+  // the logic for how to modify the logger is from: https://github.com/semantic-release/semantic-release/blob/e759493e074650748fc3bbef9e640db413b52d56/lib/plugins/normalize.js#L40
+  if (logger.scope && logger.scope instanceof Function) { // check if the logger has a scope function before calling it to try to be compatible if semantic-release ever changes the lib they use for logging 
+    // we need to get the existing scopes, convert it to an array, add the name of the plugin, then use that to modify the existing logger. 
+    let existingScopes: string[] | string = (logger as any).scopeName
+    if (typeof existingScopes === "string") {
+      existingScopes = [existingScopes]
+    }
+    existingScopes.push(deploymentPlugin.name)
 
-  isDryRun = context.options.dryRun;
+    logger = logger.scope(...existingScopes)
+  }
 
-  if (isDryRun) {
-    context.logger.log(`Oh, it looks like you are running your deployment with dry-mode enabled. I will make sure all commands I run are also run in dry-mode. I got you! 👊`)
+  // We want to return a new object so we don't modify the original context object. Our own plugin still uses the original context object.
+  // return a new one that is only passed to the deploy plugin.
+  let modifiedContext = Object.assign({}, context)
+  modifiedContext.logger = logger
+
+  return modifiedContext as CONTEXT
+}
+
+// -- Plugin lifecycle functions 
+
+export async function verifyConditions(pluginConfig: PluginConfig, context: VerifyConditionsContext) {
+  const pluginConfigOrError = parseConfig(pluginConfig)
+  if (pluginConfigOrError instanceof Error) {
+    throw pluginConfigOrError
+  }
+
+  // This is the first function that semantic-release calls on a plugin. 
+  // Check if the deployment plugin is already installed. If not, we must throw an error because we cannot install it for them. 
+  // I have tried to do that, but it seems that node loads all modules at startup so it cannot find a module after it's installed during runtime.   
+  for (const plugin of pluginConfigOrError) {
+    let alreadyInstalledPlugin = await npm.getDeploymentPlugin(plugin.name)
+    if (!alreadyInstalledPlugin) {
+      throw new Error(`Deployment plugin, ${plugin.name}, doesn't seem to be installed. Install it with npm and then try running your deployment again.`)
+    }
+
+    deploymentPlugins.push({
+      module: alreadyInstalledPlugin,
+      config: plugin
+    })
+  }
+
+  context.logger.log(`Deployment plugins found: ${deploymentPlugins.map(plugin => plugin.config.name).join(", ")}`)
+
+  for (const deployPlugin of deploymentPlugins) {
+    if (deployPlugin.module.verifyConditions) {
+      await deployPlugin.module.verifyConditions(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+    }
   }
 }
 
-export async function verifyRelease(pluginConfig: {}, context: VerifyReleaseContext) {
-  nextRelease = context.nextRelease;
-
-  context.logger.log(`Next release is planned to be: ${nextRelease.gitTag}. If this deployment fails, I will delete the git tag: ${nextRelease.gitTag}.`)
-  if (isDryRun) {
-    context.logger.log(`Well, I will pretend to delete it, since you are running in dry-mode. 😉`)
-  }  
-}
-
-export async function fail(pluginConfig: {}, context: FailContext) {
-  if (!nextRelease) {
-    return 
-  }
-
-  context.logger.log(`Looks like something went wrong during the deployment. No worries! I will try to help by cleaning up after the failed deployment so you can re-try the deployment if you wish.`)
-
-  context.logger.log(`Deleting git tag ${nextRelease.gitTag}...`)
-  if (isDryRun) {
-    context.logger.log(`(Well, not really deleting it. You are running in dry-mode. I am just playing pretend here. 🧙‍♂️)`)
-  }
-  await git.deleteTag(nextRelease.gitTag, isDryRun, context)
-
-  context.logger.log(`Done! Cleanup is complete and you should be able to retry the deployment now.`)
-  if (isDryRun) {
-    context.logger.log(`Well, technically a deployment was not actually attempted. You can try for *real* now. 😉`)
+export async function analyzeCommits(pluginConfig: PluginConfig, context: AnalyzeCommitsContext) {  
+  for (const deployPlugin of deploymentPlugins) {
+    if (deployPlugin.module.analyzeCommits) {
+      await deployPlugin.module.analyzeCommits(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+    }
   }
 }
+
+export async function verifyRelease(pluginConfig: PluginConfig, context: VerifyReleaseContext) {
+  for (const deployPlugin of deploymentPlugins) {
+    if (deployPlugin.module.verifyRelease) {
+      await deployPlugin.module.verifyRelease(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+    }
+  }
+}
+
+export async function generateNotes(pluginConfig: PluginConfig, context: VerifyReleaseContext) {
+  for (const deployPlugin of deploymentPlugins) {
+    if (deployPlugin.module.generateNotes) {
+      await deployPlugin.module.generateNotes(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+    }
+  }
+}
+
+export async function prepare(pluginConfig: PluginConfig, context: PrepareContext) {
+  for (const deployPlugin of deploymentPlugins) {
+    if (deployPlugin.module.prepare) {
+      await deployPlugin.module.prepare(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+    }
+  }
+}
+
+export async function publish(pluginConfig: PluginConfig, context: PublishContext) {  
+  for (const deployPlugin of deploymentPlugins) {
+    if (deployPlugin.module.publish) {
+      context.logger.log(`Running publish step for deployment plugin: ${deployPlugin.config.name}`)
+
+      try {
+        await deployPlugin.module.publish(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+      } catch (error) {
+        context.logger.log(`Looks like something went wrong during the deployment. No worries! I will try to help by cleaning up after the failed deployment so you can re-try the deployment if you wish.`)
+
+        // delete git tag that semantic-release created so that you can retry deployment. 
+        const gitTagToDelete = context.nextRelease.gitTag
+        context.logger.log(`Deleting git tag ${gitTagToDelete}...`)
+        await git.deleteTag(gitTagToDelete, context)    
+        context.logger.log(`Done! Cleanup is complete and you should be able to retry the deployment now.`) 
+        
+        // re-throw the error as this is the behavior that semantic-release expects.
+        // thrown errors by any plugin are meant to stop execution of semantic-release.
+        throw error
+      }
+    }
+  }
+}
+
+export async function addChannel(pluginConfig: PluginConfig, context: AddChannelContext) {  
+  for (const deployPlugin of deploymentPlugins) {
+    if (deployPlugin.module.addChannel) {
+      await deployPlugin.module.addChannel(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+    }
+  }
+}
+
+export async function success(pluginConfig: PluginConfig, context: SuccessContext) {
+  for (const deployPlugin of deploymentPlugins) {
+    if (deployPlugin.module.success) {
+      await deployPlugin.module.success(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+    }
+  }
+}
+
+export async function fail(pluginConfig: PluginConfig, context: FailContext) {  
+  for (const deployPlugin of deploymentPlugins) {
+    if (deployPlugin.module.fail) {
+      await deployPlugin.module.fail(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+    }
+  }
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 import { FailContext, VerifyReleaseContext, VerifyConditionsContext, AnalyzeCommitsContext, PrepareContext, PublishContext, AddChannelContext, SuccessContext, BaseContext } from "semantic-release"
-import { PluginConfig, parseConfig, DeploymentPlugin } from "./type/pluginConfig";
-import * as npm from "./npm";
-import { SemanticReleasePlugin } from "./type/semanticReleasePlugin";
-import * as git from "./git"
+import { PluginConfig, parseConfig, DeploymentPlugin } from "./type/pluginConfig.js";
+import * as npm from "./npm.js";
+import { SemanticReleasePlugin } from "./type/semanticReleasePlugin.js";
+import * as git from "./git.js"
+import { getDeploymentPluginLogger, getLogger } from "./logger.js"
 
 // global variables used by the whole plugin as it goes through semantic-release lifecycle
 // Deployment plugins that are parsed, loaded, and ready to call functions on. 
@@ -12,35 +13,12 @@ export function resetPlugin() { // useful for running tests
   deploymentPlugins = []
 }
 
-// semantic-release uses a lib called signale for logging. This lib helps semantic-release make logs better by telling you what plugin is executing. 
-// Because this plugin's job is to execute another plugin, we want to do the same thing that semantic-release does to show when the deploy plugin is executing. 
-// We should see logs such as: 
-// [semantic-release] [semantic-release-precheck] Running verifyConditions for deployment plugin: @semantic-release/npm
-// [semantic-release] [@semantic-release/npm] running publish step here. 
-// Depending on what plugin is running, our precheck plugin or the deploy plugin. 
-// 
-// This function modifies the context object with the modified logger so we can send the modified context to the deploy plugin.
-export function prepareLoggerForDeploymentPlugin<CONTEXT>(context: BaseContext, deploymentPlugin: DeploymentPlugin): CONTEXT {
-  let logger = context.logger 
-
-  // the logic for how to modify the logger is from: https://github.com/semantic-release/semantic-release/blob/e759493e074650748fc3bbef9e640db413b52d56/lib/plugins/normalize.js#L40
-  if (logger.scope && logger.scope instanceof Function) { // check if the logger has a scope function before calling it to try to be compatible if semantic-release ever changes the lib they use for logging 
-    // we need to get the existing scopes, convert it to an array, add the name of the plugin, then use that to modify the existing logger. 
-    let existingScopes: string[] | string = (logger as any).scopeName
-    if (typeof existingScopes === "string") {
-      existingScopes = [existingScopes]
-    }
-    existingScopes.push(deploymentPlugin.name)
-
-    logger = logger.scope(...existingScopes)
-  }
-
-  // We want to return a new object so we don't modify the original context object. Our own plugin still uses the original context object.
-  // return a new one that is only passed to the deploy plugin.
-  let modifiedContext = Object.assign({}, context)
-  modifiedContext.logger = logger
-
-  return modifiedContext as CONTEXT
+function modifyContext(args: {context: BaseContext, deployPluginConfig: DeploymentPlugin, isForDeploymentPlugin: boolean}) {
+  if (args.isForDeploymentPlugin) {
+    args.context.logger = getDeploymentPluginLogger(args.context, args.deployPluginConfig)
+  } else {
+    args.context.logger = getLogger(args.context, args.deployPluginConfig)
+  }  
 }
 
 // -- Plugin lifecycle functions 
@@ -69,59 +47,75 @@ export async function verifyConditions(pluginConfig: PluginConfig, context: Veri
   context.logger.log(`Deployment plugins found: ${deploymentPlugins.map(plugin => plugin.config.name).join(", ")}`)
 
   for (const deployPlugin of deploymentPlugins) {
+    modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: true})
+
     if (deployPlugin.module.verifyConditions) {
-      await deployPlugin.module.verifyConditions(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+      await deployPlugin.module.verifyConditions(deployPlugin.config.config || {}, context)
     }
   }
 }
 
 export async function analyzeCommits(pluginConfig: PluginConfig, context: AnalyzeCommitsContext) {  
   for (const deployPlugin of deploymentPlugins) {
+    modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: true})
+
     if (deployPlugin.module.analyzeCommits) {
-      await deployPlugin.module.analyzeCommits(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+      await deployPlugin.module.analyzeCommits(deployPlugin.config.config || {}, context)
     }
   }
 }
 
 export async function verifyRelease(pluginConfig: PluginConfig, context: VerifyReleaseContext) {
   for (const deployPlugin of deploymentPlugins) {
+    modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: true})
+
     if (deployPlugin.module.verifyRelease) {
-      await deployPlugin.module.verifyRelease(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+      await deployPlugin.module.verifyRelease(deployPlugin.config.config || {}, context)
     }
   }
 }
 
 export async function generateNotes(pluginConfig: PluginConfig, context: VerifyReleaseContext) {
   for (const deployPlugin of deploymentPlugins) {
+    modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: true})
+
     if (deployPlugin.module.generateNotes) {
-      await deployPlugin.module.generateNotes(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+      await deployPlugin.module.generateNotes(deployPlugin.config.config || {}, context)
     }
   }
 }
 
 export async function prepare(pluginConfig: PluginConfig, context: PrepareContext) {
   for (const deployPlugin of deploymentPlugins) {
+    modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: true})
+
     if (deployPlugin.module.prepare) {
-      await deployPlugin.module.prepare(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+      await deployPlugin.module.prepare(deployPlugin.config.config || {}, context)
     }
   }
 }
 
-export async function publish(pluginConfig: PluginConfig, context: PublishContext) {  
+export async function publish(pluginConfig: PluginConfig, context: PublishContext) {
   for (const deployPlugin of deploymentPlugins) {
     if (deployPlugin.module.publish) {
+      modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: false})
       context.logger.log(`Running publish step for deployment plugin: ${deployPlugin.config.name}`)
-
-      try {
-        await deployPlugin.module.publish(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+      
+      modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: true})
+      try {        
+        await deployPlugin.module.publish(deployPlugin.config.config || {}, context)
       } catch (error) {
+        modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: false})
+
         context.logger.log(`Looks like something went wrong during the deployment. No worries! I will try to help by cleaning up after the failed deployment so you can re-try the deployment if you wish.`)
 
         // delete git tag that semantic-release created so that you can retry deployment. 
         const gitTagToDelete = context.nextRelease.gitTag
         context.logger.log(`Deleting git tag ${gitTagToDelete}...`)
         await git.deleteTag(gitTagToDelete, context)    
-        context.logger.log(`Done! Cleanup is complete and you should be able to retry the deployment now.`) 
+        context.logger.log(`Cleanup is complete and you should be able to retry the deployment now.`) 
+
+        context.logger.log(`Re-throwing error thrown by ${deployPlugin.config.name} to stop semantic-release from continuing to deploy.`) 
         
         // re-throw the error as this is the behavior that semantic-release expects.
         // thrown errors by any plugin are meant to stop execution of semantic-release.
@@ -133,24 +127,30 @@ export async function publish(pluginConfig: PluginConfig, context: PublishContex
 
 export async function addChannel(pluginConfig: PluginConfig, context: AddChannelContext) {  
   for (const deployPlugin of deploymentPlugins) {
+    modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: true})
+
     if (deployPlugin.module.addChannel) {
-      await deployPlugin.module.addChannel(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+      await deployPlugin.module.addChannel(deployPlugin.config.config || {}, context)
     }
   }
 }
 
 export async function success(pluginConfig: PluginConfig, context: SuccessContext) {
   for (const deployPlugin of deploymentPlugins) {
+    modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: true})
+
     if (deployPlugin.module.success) {
-      await deployPlugin.module.success(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+      await deployPlugin.module.success(deployPlugin.config.config || {}, context)
     }
   }
 }
 
 export async function fail(pluginConfig: PluginConfig, context: FailContext) {  
   for (const deployPlugin of deploymentPlugins) {
+    modifyContext({context, deployPluginConfig: deployPlugin.config, isForDeploymentPlugin: true})
+
     if (deployPlugin.module.fail) {
-      await deployPlugin.module.fail(deployPlugin.config.config || {}, prepareLoggerForDeploymentPlugin(context, deployPlugin.config))
+      await deployPlugin.module.fail(deployPlugin.config.config || {}, context)
     }
   }
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,51 @@
+import { BaseContext } from "semantic-release"
+import { DeploymentPlugin } from "./type/pluginConfig.js"
+
+export interface SemanticReleaseLogger {
+  log: (message: string) => void
+  error: (message: string) => void
+}
+
+// semantic-release uses a lib called signale for logging. This lib helps semantic-release make logs better by telling you what plugin is executing. 
+// Because this plugin's job is to execute another plugin, we want to do the same thing that semantic-release does to show when the deploy plugin is executing. 
+// We should see logs such as: 
+// [semantic-release] [semantic-release-precheck] Running verifyConditions for deployment plugin: @semantic-release/npm
+// [semantic-release] [semantic-release-precheck] [@semantic-release/npm] running publish step here. 
+// Depending on what plugin is running, our precheck plugin or the deploy plugin. 
+// 
+// These functions get us the logger that we need for each case.
+
+export const getDeploymentPluginLogger = (context: BaseContext, deploymentPlugin: DeploymentPlugin): SemanticReleaseLogger => {
+  return getSemanticReleaseLogger({context, deploymentPlugin, isLoggerForDeploymentPlugin: true})
+}
+
+export const getLogger = (context: BaseContext, deploymentPlugin: DeploymentPlugin): SemanticReleaseLogger => {
+  return getSemanticReleaseLogger({context, deploymentPlugin, isLoggerForDeploymentPlugin: false})
+}
+
+const getSemanticReleaseLogger = (args: {context: BaseContext, deploymentPlugin: DeploymentPlugin, isLoggerForDeploymentPlugin: Boolean}): SemanticReleaseLogger => {
+  let logger = args.context.logger
+
+  // the logic for how to modify the logger is from: https://github.com/semantic-release/semantic-release/blob/e759493e074650748fc3bbef9e640db413b52d56/lib/plugins/normalize.js#L40
+  if (logger.scope && logger.scope instanceof Function) { // check if the logger has a scope function before calling it to try to be compatible if semantic-release ever changes the lib they use for logging 
+    // we need to get the existing scopes, convert it to an array, add the name of the plugin, then use that to modify the existing logger. 
+    let existingScopes: string[] | string = (logger as any).scopeName
+    if (typeof existingScopes === "string") {
+      existingScopes = [existingScopes]
+    }
+
+    if (args.isLoggerForDeploymentPlugin) {
+      // Add deployment plugin name. 
+      // Logs should look like: [semantic-release] [@semantic-release/npm] running publish step here.
+      existingScopes.push(args.deploymentPlugin.name)
+    } else {
+      // Remove deployment plugin name. 
+      // Logs should look like: [semantic-release] [semantic-release-recovery] we are deleting git tag 
+      existingScopes = existingScopes.filter(scope => scope !== args.deploymentPlugin.name)
+    }
+
+    logger = logger.scope(...existingScopes)
+  }
+
+  return logger 
+}

--- a/src/npm.spec.ts
+++ b/src/npm.spec.ts
@@ -1,0 +1,12 @@
+import * as npm from './npm'
+
+describe('getDeploymentPlugin', () => {
+  it('should return undefined for a npm module not installed', async() => {
+    expect(await npm.getDeploymentPlugin('not-installed')).toBeUndefined()
+  })
+  it('should return an object for a npm module already installed', async() => {
+    let npmDeploymentPlugin = await npm.getDeploymentPlugin('@semantic-release/npm')
+    expect(npmDeploymentPlugin).toBeDefined()
+    expect(npmDeploymentPlugin?.publish).toBeDefined() // Helps us feel more confident the module was loaded because we should find a publish function. 
+  })
+})

--- a/src/npm.spec.ts
+++ b/src/npm.spec.ts
@@ -1,4 +1,4 @@
-import * as npm from './npm'
+import * as npm from './npm.js'
 
 describe('getDeploymentPlugin', () => {
   it('should return undefined for a npm module not installed', async() => {

--- a/src/npm.spec.ts
+++ b/src/npm.spec.ts
@@ -1,4 +1,4 @@
-import * as npm from './npm.js'
+import {npm} from './npm.js'
 
 describe('getDeploymentPlugin', () => {
   it('should return undefined for a npm module not installed', async() => {

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,11 +1,43 @@
 import { SemanticReleasePlugin } from "./type/semanticReleasePlugin.js";
 
-// Note: Must run jest tests with `NODE_OPTIONS=--experimental-vm-modules` to allow esm modules to be imported since some semantic-release plugins are esm only
-export async function getDeploymentPlugin(name: string): Promise<SemanticReleasePlugin | undefined> {
-  try {
-    let plugin = await import(name)
-    return plugin
-  } catch (e) {
-    return undefined
+export interface Npm {
+  getDeploymentPlugin(name: string): Promise<SemanticReleasePlugin | undefined>
+}
+
+export class NpmImpl implements Npm {
+  async getDeploymentPlugin(name: string): Promise<SemanticReleasePlugin | undefined> {
+    try {
+      let plugin = await import(name)
+      return plugin
+    } catch (e) {
+      return undefined
+    }
   }
 }
+
+class NpmMock implements Npm {  
+  callCount: Map<string, number> = new Map()
+  call: Map<string, any> = new Map()
+  calls: Map<string, any[]> = new Map()
+
+  getDeploymentPluginReturn: Promise<SemanticReleasePlugin | undefined> = Promise.resolve(undefined)
+
+  getDeploymentPlugin(name: string): Promise<SemanticReleasePlugin | undefined> {
+    this.callCount.set('getDeploymentPlugin', (this.callCount.get('getDeploymentPlugin') || 0) + 1)
+    this.call.set('getDeploymentPlugin', {name})
+
+    let existingCalls = this.calls.get('getDeploymentPlugin') || []
+    existingCalls.push({name})
+    this.calls.set('getDeploymentPlugin', existingCalls)
+
+    return this.getDeploymentPluginReturn
+  }
+}
+
+export let npm: Npm = new NpmImpl()
+export let npmMock = new NpmMock()
+export const mockNpm = () => {
+  npmMock = new NpmMock()
+  npm = npmMock
+}
+

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,4 +1,4 @@
-import { SemanticReleasePlugin } from "./type/semanticReleasePlugin";
+import { SemanticReleasePlugin } from "./type/semanticReleasePlugin.js";
 
 // Note: Must run jest tests with `NODE_OPTIONS=--experimental-vm-modules` to allow esm modules to be imported since some semantic-release plugins are esm only
 export async function getDeploymentPlugin(name: string): Promise<SemanticReleasePlugin | undefined> {

--- a/src/npm.ts
+++ b/src/npm.ts
@@ -1,0 +1,11 @@
+import { SemanticReleasePlugin } from "./type/semanticReleasePlugin";
+
+// Note: Must run jest tests with `NODE_OPTIONS=--experimental-vm-modules` to allow esm modules to be imported since some semantic-release plugins are esm only
+export async function getDeploymentPlugin(name: string): Promise<SemanticReleasePlugin | undefined> {
+  try {
+    let plugin = await import(name)
+    return plugin
+  } catch (e) {
+    return undefined
+  }
+}

--- a/src/type/pluginConfig.spec.ts
+++ b/src/type/pluginConfig.spec.ts
@@ -1,0 +1,32 @@
+import { PluginConfig, parseConfig } from "./pluginConfig"
+
+describe('parseConfig', () => {
+  it('should return error if no config defined', () => {
+    expect(parseConfig({})).toBeInstanceOf(Error)
+  })
+
+  it('should return error if config doesnt define plugins', () => {
+    expect(parseConfig({foo: false})).toBeInstanceOf(Error)
+  })
+
+  it('should return error if no plugins are defined', () => {
+    expect(parseConfig({plugins: []})).toBeInstanceOf(Error)
+  })
+
+  it('should return error if no plugins are defined', () => {
+    const expected = [
+      {
+        name: '@semantic-release/npm',
+        config: {
+          npmPublish: false
+        }
+      }
+    ]    
+
+    expect(parseConfig({plugins: [
+      ['@semantic-release/npm', {
+        npmPublish: false
+      }]
+    ]})).toEqual(expected)
+  })
+})

--- a/src/type/pluginConfig.spec.ts
+++ b/src/type/pluginConfig.spec.ts
@@ -1,4 +1,4 @@
-import { PluginConfig, parseConfig } from "./pluginConfig"
+import { PluginConfig, parseConfig } from "./pluginConfig.js"
 
 describe('parseConfig', () => {
   it('should return error if no config defined', () => {

--- a/src/type/pluginConfig.ts
+++ b/src/type/pluginConfig.ts
@@ -1,0 +1,26 @@
+export interface DeploymentPlugin {
+  name: string
+  config: object
+}
+
+export type PluginConfig = Array<DeploymentPlugin>
+
+// returns a string (error message) if invalid. 
+export function parseConfig(config: any): Error | PluginConfig {  
+  if (!config.plugins) return Error(`Configuration for plugin is in an incorrect format. See docs for how to implement.`)
+
+  try {
+    const deploymentPlugins = config.plugins.map((plugin: any[]) => {
+      return {
+        name: plugin[0] as string,
+        config: plugin[1]
+      }
+    })
+
+    if (deploymentPlugins.length === 0) return Error(`No deployment plugins found. See docs for how to implement.`)
+
+    return deploymentPlugins
+  } catch (error) {
+    return Error(`Configuration for plugin is in an incorrect format. See docs for how to implement. Error thrown: ${error}`)
+  }  
+}

--- a/src/type/semanticReleasePlugin.ts
+++ b/src/type/semanticReleasePlugin.ts
@@ -1,0 +1,13 @@
+import { FailContext, VerifyReleaseContext, VerifyConditionsContext, AnalyzeCommitsContext, GenerateNotesContext, PrepareContext, PublishContext, AddChannelContext, SuccessContext } from "semantic-release"
+
+export interface SemanticReleasePlugin {
+  verifyConditions?: (pluginConfig: Object, context: VerifyConditionsContext) => Promise<void>
+  analyzeCommits?: (pluginConfig: Object, context: AnalyzeCommitsContext) => Promise<void>
+  verifyRelease?: (pluginConfig: Object, context: VerifyReleaseContext) => Promise<void>
+  generateNotes?: (pluginConfig: Object, context: GenerateNotesContext) => Promise<void>
+  prepare?: (pluginConfig: Object, context: PrepareContext) => Promise<void>
+  publish?: (pluginConfig: Object, context: PublishContext) => Promise<void>
+  addChannel?: (pluginConfig: Object, context: AddChannelContext) => Promise<void>
+  success?: (pluginConfig: Object, context: SuccessContext) => Promise<void>
+  fail?: (pluginConfig: Object, context: FailContext) => Promise<void>
+}

--- a/src/type/semanticReleasePlugin.ts
+++ b/src/type/semanticReleasePlugin.ts
@@ -11,3 +11,68 @@ export interface SemanticReleasePlugin {
   success?: (pluginConfig: Object, context: SuccessContext) => Promise<void>
   fail?: (pluginConfig: Object, context: FailContext) => Promise<void>
 }
+
+export class MockSemanticReleasePlugin implements SemanticReleasePlugin {
+  verifyConditionsCallCount: number = 0
+  verifyConditionsArgs: {pluginConfig: Object, context: VerifyConditionsContext}[] = []
+  async verifyConditions(pluginConfig: Object, context: VerifyConditionsContext): Promise<void> {
+    this.verifyConditionsCallCount++
+    this.verifyConditionsArgs.push({pluginConfig, context})
+  }
+
+  analyzeCommitsCallCount: number = 0
+  analyzeCommitsArgs: {pluginConfig: Object, context: AnalyzeCommitsContext}[] = []
+  async analyzeCommits(pluginConfig: Object, context: AnalyzeCommitsContext): Promise<void> {
+    this.analyzeCommitsCallCount++
+    this.analyzeCommitsArgs.push({pluginConfig, context})
+  }
+
+  verifyReleaseCallCount: number = 0
+  verifyReleaseArgs: {pluginConfig: Object, context: VerifyReleaseContext}[] = []
+  async verifyRelease(pluginConfig: Object, context: VerifyReleaseContext): Promise<void> {
+    this.verifyReleaseCallCount++
+    this.verifyReleaseArgs.push({pluginConfig, context})
+  }
+
+  generateNotesCallCount: number = 0
+  generateNotesArgs: {pluginConfig: Object, context: GenerateNotesContext}[] = []
+  async generateNotes(pluginConfig: Object, context: GenerateNotesContext): Promise<void> {
+    this.generateNotesCallCount++
+    this.generateNotesArgs.push({pluginConfig, context})
+  }
+
+  prepareCallCount: number = 0
+  prepareArgs: {pluginConfig: Object, context: PrepareContext}[] = []
+  async prepare(pluginConfig: Object, context: PrepareContext): Promise<void> {
+    this.prepareCallCount++
+    this.prepareArgs.push({pluginConfig, context})
+  }
+
+  publishCallCount: number = 0
+  publishArgs: {pluginConfig: Object, context: PublishContext}[] = []
+  async publish(pluginConfig: Object, context: PublishContext): Promise<void> {
+    this.publishCallCount++
+    this.publishArgs.push({pluginConfig, context})
+  }
+
+  addChannelCallCount: number = 0
+  addChannelArgs: {pluginConfig: Object, context: AddChannelContext}[] = []
+  async addChannel(pluginConfig: Object, context: AddChannelContext): Promise<void> {
+    this.addChannelCallCount++
+    this.addChannelArgs.push({pluginConfig, context})
+  }
+
+  successCallCount: number = 0
+  successArgs: {pluginConfig: Object, context: SuccessContext}[] = []
+  async success(pluginConfig: Object, context: SuccessContext): Promise<void> {
+    this.successCallCount++
+    this.successArgs.push({pluginConfig, context})
+  }
+
+  failCallCount: number = 0
+  failArgs: {pluginConfig: Object, context: FailContext}[] = []
+  async fail(pluginConfig: Object, context: FailContext): Promise<void> {
+    this.failCallCount++
+    this.failArgs.push({pluginConfig, context})
+  }
+}


### PR DESCRIPTION
After using plugin in a project, I realized that fail step doesnt actually get called when a deployment plugin fails. If publish step 
fails, semantic-release will fail and exit early running no more steps. This PR fixes the plugin by moving git tag deletion logic into 
publish step. Also, configuration of this plugin is easier with updated syntax.
